### PR TITLE
Two column layout for showcase

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+web:
+  image: heroku/nodejs
+  working_dir: /app/user
+  volumes:
+    - .:/app/user
+  command: npm run run
+  ports:
+    - "3000:3000"

--- a/routes/index.js
+++ b/routes/index.js
@@ -26,7 +26,19 @@ function legacy(req, res) {
 }
 
 function showcase(req, res) {
-  res.render('showcase', { title: TITLE, theme: req.query.theme })
+    var showcase = req.config.showcase;
+    var col1 = [];
+    var col2 = [];
+
+    for (var i = 0; i < showcase.length; i++) {
+        if (i % 2 === 0) {
+            col1.push(showcase[i]);
+        } else {
+            col2.push(showcase[i]);
+        }
+    }
+
+    res.render('showcase', { title: TITLE, theme: req.query.theme, col1: col1, col2: col2 })
 }
 
 module.exports = {

--- a/views/_partials/header.jade
+++ b/views/_partials/header.jade
@@ -15,11 +15,11 @@
                 li: a(href="/bootswatch/" + themeQs) Bootswatch
                 li: a(href="/bootlint/" + themeQs) Bootlint
                 li: a(href="/legacy/" + themeQs) Legacy
-                li: a(href="/alpha/" + themeQs) Bootstrap4
-                    sup ALPHA
-                //-li: a(href="/showcase/" + themeQs) Showcase
+                li: a(href="/showcase/" + themeQs) Showcase
 
             ul.nav.navbar-nav.navbar-right.visible-md.visible-lg
+                li: a(href="/alpha/" + themeQs) Bootstrap4
+                    sup ALPHA
                 li.dropdown
                     a.dropdown-toggle(href="#", data-toggle="dropdown") Resources&nbsp;
                         i.fa.fa-caret-down

--- a/views/_partials/showcase.jade
+++ b/views/_partials/showcase.jade
@@ -1,6 +1,6 @@
 hr
 br
-a(href=item.url, target="_blank"): img(src=item.img, class="img-responsive", style="margin: 0 auto")
+a(href=item.url, target="_blank"): img.img-responsive.thumbnail(src=item.img, style="margin: 0 auto")
 h3: a(href=item.url, target="_blank")=item.name
 | Libraries: 
 span=item.lib

--- a/views/_partials/showcase.jade
+++ b/views/_partials/showcase.jade
@@ -1,0 +1,8 @@
+hr
+br
+a(href=item.url, target="_blank"): img(src=item.img, class="img-responsive", style="margin: 0 auto")
+h3: a(href=item.url, target="_blank")=item.name
+| Libraries: 
+span=item.lib
+br
+

--- a/views/showcase.jade
+++ b/views/showcase.jade
@@ -2,15 +2,25 @@ extends layout
 
 block content
     h2 Showcase
-    .well.text-center
-        - each item in config.showcase
-            .row
-                .col-md-12.text-center
-                    br
-                    br
-                    img(src=item.img, class="img-responsive", style="margin: 0 auto")
-                    h3: a(href=item.url, target="_blank")=item.name
-                    | Libraries: 
-                    span=item.lib
+    .row
+        .col-md-6.text-center
+            - each item in col1
+                hr
+                br
+                img(src=item.img, class="img-responsive", style="margin: 0 auto")
+                h3: a(href=item.url, target="_blank")=item.name
+                | Libraries: 
+                span=item.lib
+                br
+
+        .col-md-6.text-center
+            - each item in col2
+                hr
+                br
+                img(src=item.img, class="img-responsive", style="margin: 0 auto")
+                h3: a(href=item.url, target="_blank")=item.name
+                | Libraries: 
+                span=item.lib
+                br
 
 //- vim: ft=jade sw=4 sts=4 et:

--- a/views/showcase.jade
+++ b/views/showcase.jade
@@ -5,22 +5,10 @@ block content
     .row
         .col-md-6.text-center
             - each item in col1
-                hr
-                br
-                img(src=item.img, class="img-responsive", style="margin: 0 auto")
-                h3: a(href=item.url, target="_blank")=item.name
-                | Libraries: 
-                span=item.lib
-                br
+                include _partials/showcase.jade
 
         .col-md-6.text-center
             - each item in col2
-                hr
-                br
-                img(src=item.img, class="img-responsive", style="margin: 0 auto")
-                h3: a(href=item.url, target="_blank")=item.name
-                | Libraries: 
-                span=item.lib
-                br
+                include _partials/showcase.jade
 
 //- vim: ft=jade sw=4 sts=4 et:


### PR DESCRIPTION
@jdorfman deployed here: https://bscdnpre.herokuapp.com/showcase/

added:

- two col layout for showcase
- linked showcase imgs
- reactivated showcase nav
- moved bootstrap4 alpha link to left side of nav
- added `docker-compose.yml` supporting the heroku/nodejs docker image
    - usage

```bash
# setup, test, run
docker-compose run --rm web npm install && \
    docker-compose run --rm web npm test && \
    docker-compose up
```