### PR TITLE
Fix font awesome flag icon mistake

### DIFF
--- a/views/_partials/header.jade
+++ b/views/_partials/header.jade
@@ -10,8 +10,9 @@
             a.navbar-brand(href="/" + themeQs) BootstrapCDN
         .navbar-collapse.collapse
             ul.nav.navbar-nav
-                li: a(href="/fontawesome/" + themeQs): i.fa.fa-flag
-                    | Font Awesome
+                li: a(href="/fontawesome/" + themeQs)
+                  i.fa.fa-flag
+                  | &nbsp;Font Awesome
                 li: a(href="/bootswatch/" + themeQs) Bootswatch
                 li: a(href="/bootlint/" + themeQs) Bootlint
                 li: a(href="/legacy/" + themeQs) Legacy


### PR DESCRIPTION
There was a mistake that I had noticed on the website, the font was a little off for the Font Awesome link on the navbar. I checked the source code, and noticed this: `<i class="fa fa-flag">Font Awesome</i>`


I fixed this to display as `<i class="fa fa-flag"></i> Font Awesome` so that it didn't glitch the font out.

