### PR TITLE
Update after.jade

### DIFF
--- a/views/_partials/javascripts/after.jade
+++ b/views/_partials/javascripts/after.jade
@@ -55,6 +55,6 @@ script
 script(async src="https://platform.twitter.com/widgets.js")
 
 - if (bootlint)
-    script(src=bootlint.javascript, integrity=bootlint.javascript_sri)
+    script(src=bootlint.javascript, integrity=bootlint.javascript_sri, crossorigin="anonymous")
 
 //- vim: ft=jade sw=4 sts=4 et:


### PR DESCRIPTION
Add missing `crossorigin="anonymous"` for bootlint.min.js.

Fixes #660.