### PR TITLE
It's WordPress, dangit!

### DIFF
--- a/views/_partials/header.jade
+++ b/views/_partials/header.jade
@@ -29,7 +29,7 @@
                                 onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'GitHub project']);") GitHub project
                         li
                             a(href="https://wordpress.org/plugins/bootstrapcdn/",
-                                onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'Wordpress Plugin']);") Wordpress Plugin
+                                onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'WordPress Plugin']);") WordPress Plugin
                         li
                             a(href="http://getbootstrap.com/",
                                 onclick="_gaq.push(['_trackEvent', 'Navigation', 'Resources', 'Bootstrap']);") Bootstrap


### PR DESCRIPTION
It should be WordPress, not Wordpress. The community is pretty serious about this. :)

Fixes: https://github.com/MaxCDN/bootstrap-cdn/issues/668