### PR TITLE
removing etag and adjusting cache-control headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,12 @@ Key Overview:
 2. `theme`: Integer value of the array index from the `bootswatch` section below.
 3. `authors`: Array of Author Strings
 4. `description`: String containing the meta description of the site.
-5. `favicon`: Hash containing the favicon path.
-6. `google_analytics`: Hash containing GA `account_id` and `domain_name`.
-7. `stylesheets`: Array containing stylesheet files to be loaded at the top of the site.
-8. `javascripts`: Array containing javascript files to be loaded either `before` (at the top) or `after` (at the bottom) of the site.
-9. `bootswatch`: Hash containing current Bootswatch meta data and themes.
-10. `bootlint`: Array of Hashes containing Bootlint meta data and pathing.
-11. `bootstrap`: Array of Hashes containing Bootstrap meta data and pathing.
+5. `google_analytics`: Hash containing GA `account_id` and `domain_name`.
+6. `stylesheets`: Array containing stylesheet files to be loaded at the top of the site.
+7. `javascripts`: Array containing javascript files to be loaded either `before` (at the top) or `after` (at the bottom) of the site.
+8. `bootswatch`: Hash containing current Bootswatch meta data and themes.
+9. `bootlint`: Array of Hashes containing Bootlint meta data and pathing.
+10. `bootstrap`: Array of Hashes containing Bootstrap meta data and pathing.
 
 ### `config/_tweets.yml`
 

--- a/app.js
+++ b/app.js
@@ -44,7 +44,12 @@ if (env === 'production') {
     app.use(errorHandler({ dumpExceptions: true, showStack: true }));
 }
 
+// middleware
 app.use(require('compression')());
+app.set('etag', false);
+
+app.use(favicon(path.join(__dirname, 'public', config.favicon.uri), '7d'));
+app.use(serveStatic(path.join(__dirname, 'public'), { maxAge: '30d' }));
 
 app.use(function(req, res, next) {
     // make config available in routes
@@ -53,17 +58,10 @@ app.use(function(req, res, next) {
     // custom headers
     res.setHeader('X-Powered-By', 'MaxCDN');
     res.setHeader('X-Hello-Human', 'You must be bored. You should work for us. Email jdorfman+theheader@maxcdn.com or @jdorfman on the twitter.');
-    res.setHeader('Cache-Control', 'public, max-age=2592000');
-
-    var oneMonth = 30 * 24 * 60 * 60 * 1000;
-    res.setHeader('Expires', new Date(Date.now() + oneMonth).toUTCString());
+    res.setHeader('Cache-Control', 'public, max-age=3600');
 
     next();
 });
-
-// middleware
-app.use(favicon(path.join(__dirname, 'public', config.favicon.uri), '7d'));
-app.use(serveStatic(path.join(__dirname, 'public')));
 
 // locals
 app.locals.helpers = require('./lib/helpers');

--- a/app.js
+++ b/app.js
@@ -2,12 +2,13 @@
 
 var env = process.env.NODE_ENV || 'development';
 
-var path    = require('path');
-var fs      = require('fs');
-var yaml    = require('js-yaml');
-var express = require('express');
-var http    = require('http');
-var app     = express();
+var path        = require('path');
+var fs          = require('fs');
+var yaml        = require('js-yaml');
+var express     = require('express');
+var http        = require('http');
+var compression = require('compression');
+var app         = express();
 
 // middleware
 var logger       = require('morgan');
@@ -44,19 +45,28 @@ if (env === 'production') {
 }
 
 // middleware
-app.use(require('compression')());
+app.use(compression());
 app.set('etag', false);
 
-app.use(serveStatic(path.join(__dirname, 'public'), { maxAge: '30d' }));
+app.use(serveStatic(path.join(__dirname, 'public'), { maxAge: '30d', lastModified: true, etag: false }));
 
 app.use(function(req, res, next) {
+    var oneHourToSec = 60 * 60;
+    var oneHourToMilliSec = 60 * 60 * 1000;
+
     // make config available in routes
     req.config = config;
 
     // custom headers
     res.setHeader('X-Powered-By', 'MaxCDN');
     res.setHeader('X-Hello-Human', 'You must be bored. You should work for us. Email jdorfman+theheader@maxcdn.com or @jdorfman on the twitter.');
-    res.setHeader('Cache-Control', 'public, max-age=3600');
+    res.setHeader('Cache-Control', 'public, max-age=' + oneHourToSec);
+    res.setHeader('Expires', new Date(Date.now() + oneHourToMilliSec).toUTCString());
+    res.setHeader('Last-Modified', new Date().toUTCString());
+    res.setHeader('Accept-Ranges', 'bytes');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('X-Frame-Options', 'DENY');
+    res.setHeader('X-XSS-Protection', '1; mode=block');
 
     next();
 });

--- a/app.js
+++ b/app.js
@@ -10,7 +10,6 @@ var http    = require('http');
 var app     = express();
 
 // middleware
-var favicon      = require('serve-favicon');
 var logger       = require('morgan');
 var serveStatic  = require('serve-static');
 var errorHandler = require('errorhandler');
@@ -48,7 +47,6 @@ if (env === 'production') {
 app.use(require('compression')());
 app.set('etag', false);
 
-app.use(favicon(path.join(__dirname, 'public', config.favicon.uri), '7d'));
 app.use(serveStatic(path.join(__dirname, 'public'), { maxAge: '30d' }));
 
 app.use(function(req, res, next) {

--- a/config/_config.yml
+++ b/config/_config.yml
@@ -7,8 +7,6 @@ description: BootstrapCDN
 google_analytics:
   account_id: UA-32253110-1
   domain_name: bootstrapcdn.com
-favicon:
-  uri: /favicon.ico
 stylesheets:
   style:
     uri: /assets/css/style.css

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "js-yaml": "^3.4.2",
     "morgan": "^1.6.1",
     "pug": "^2.0.0-beta4",
-    "serve-favicon": "^2.3.0",
     "serve-static": "^1.10.0",
     "shelljs": "^0.5.3",
     "snyk": "^1.17.1",

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -11,7 +11,7 @@ html(lang="en")
 
         link(rel='canonical', href=fullUrl)
 
-        link(rel='shortcut icon', href=config.favicon.uri)
+        link(rel='shortcut icon', href='/favicon.ico')
 
         - bootswatch = helpers.theme.fetch(config, theme);
         link(rel='stylesheet', href=bootswatch.uri, integrity=bootswatch.sri, crossorigin="anonymous")


### PR DESCRIPTION
Fixes #708, fixes #699 

Had to reorder mw a little to ensure that things were applied in the proper order. Additionally, I removed the `Expires` header, as without `ETag`, it shouldn't be necessary any more.