### PR TITLE
Fix public functional tests on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ build: off
 test_script:
   - node -v
   - npm -v
-  - node make travis
+  - node make appveyor
 
 matrix:
   fast_finish: true

--- a/make.js
+++ b/make.js
@@ -91,6 +91,13 @@ target.travis = function () {
     target.suite();
 };
 
+target.appveyor = function () {
+    target.lint();
+
+    // without functional tests
+    assertExec(MOCHA + MOCHA_OPTS + ' -i -g "functional" -R dot ./tests/');
+};
+
 target['wp-plugin'] = function () {
     echo('node ./scripts/wp-plugin.js');
     assertExec('node ./scripts/wp-plugin.js');
@@ -183,3 +190,5 @@ target.help = function () {
     echo('  travis      run Travis CI checks');
     echo('  help        shows this help message');
 };
+
+// vim: ft=javascript sw=4 sts=4 et:

--- a/tests/functional_test.js
+++ b/tests/functional_test.js
@@ -90,7 +90,6 @@ function assertHeader(uri, header) {
     }
 }
 
-// bootswatch
 describe('functional', function () {
     describe('bootstrap', function () {
         config.bootstrap.forEach(function (self) {
@@ -215,7 +214,7 @@ describe('functional', function () {
         var publicURIs = [];
 
         walk.filesSync(path.join(__dirname, '..', 'public'), function (base, name) {
-            var root = base.split('/public/')[1];
+            var root = process.platform === 'win32' ? base.split('\\public\\')[1] : base.split('/public/')[1];
 
             // ensure file is in whitelisted directory
             if (typeof root === 'undefined' || whitelist.indexOf(root.split(path.sep)[0]) === -1) {


### PR DESCRIPTION
Fixes #766

@XhmikosR This is better, but still not perfect. The primary issue was due to splitting out the directory using `/public/` where it needs to be `\\public\\` on windows. 

That said, the counts still don't match b/c `fs-walk` doesn't support symlinks on windows. I'm going to continue looking for a solution for symlinked files, but this is good start.
