### PR TITLE
Add back serve-favicon.

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ var sitemap     = require('express-sitemap');
 var app = express();
 
 // middleware
+var favicon      = require('serve-favicon');
 var logger       = require('morgan');
 var serveStatic  = require('serve-static');
 var errorHandler = require('errorhandler');
@@ -55,6 +56,8 @@ if (env === 'production') {
 // middleware
 app.use(compression());
 app.set('etag', false);
+
+app.use(favicon(path.join(__dirname, 'public', config.favicon.uri), '7d'));
 
 app.use(serveStatic(path.join(__dirname, 'public'), {
     maxAge: '30d',

--- a/config/_config.yml
+++ b/config/_config.yml
@@ -4,6 +4,8 @@ authors:
   - Joshua Mervine
   - Justin Dorfman
 description: BootstrapCDN
+favicon:
+  uri: /assets/img/favicons/favicon.ico
 stylesheets:
   style:
     uri: /assets/css/style.css

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "js-yaml": "^3.6.1",
     "morgan": "^1.7.0",
     "pug": "^2.0.0-beta6",
+    "serve-favicon": "^2.3.2",
     "serve-static": "^1.11.1",
     "shelljs": "^0.5.3",
     "snyk": "^1.19.1",


### PR DESCRIPTION
Mostly for `/favicon.ico` to work.

@jmervine: this should be doable with a couple of lines in app.js but my express.js knowledge is not very mature.

What do you think we should do?