### PR TITLE
Move Google Analytics track events to main.js.

### DIFF
--- a/app.js
+++ b/app.js
@@ -102,7 +102,6 @@ app.use(helmet.contentSecurityPolicy({
         defaultSrc: ['\'none\''],
         scriptSrc: [
             '\'self\'',
-            '\'unsafe-inline\'',
             'maxcdn.bootstrapcdn.com',
             'www.google-analytics.com',
             'code.jquery.com',

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -84,14 +84,38 @@
         }
     })();
 
-    /* eslint-disable */
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-    ga('create', 'UA-32253110-1', 'bootstrapcdn.com');
-    ga('send', 'pageview');
-    /* eslint-enable */
+    (function () {
+        function gaEvent(e) {
+            if (typeof e.target !== 'undefined') {
+                var action = e.target.getAttribute('data-ga-action');
+                var category = e.target.getAttribute('data-ga-category');
+                var label = e.target.getAttribute('data-ga-label');
+                var value = parseInt(e.target.getAttribute('data-ga-value'), 10);
+
+                if (typeof ga !== 'undefined' && typeof category !== 'undefined' && typeof action !== 'undefined') {
+                    window.ga('send', 'event', category, action, label, value, {});
+                }
+            }
+        }
+
+        /* eslint-disable */
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+        ga('create', 'UA-32253110-1', 'bootstrapcdn.com');
+        ga('send', 'pageview');
+
+        if (window.addEventListener) {
+            window.addEventListener('click', gaEvent, false);
+        } else if (window.attachEvent) {
+            window.attachEvent('click', gaEvent);
+        } else {
+            window.onclick = gaEvent;
+        }
+        /* eslint-enable */
+    })();
 
 })();

--- a/views/_partials/header.pug
+++ b/views/_partials/header.pug
@@ -1,4 +1,4 @@
-- themeQs = theme ? '?theme='+theme : ''
+- themeQs = theme ? '?theme=' + theme : ''
 .navbar.navbar-default.navbar-static-top(role="navigation")
     .container-fluid
         .navbar-header
@@ -32,27 +32,43 @@
                     ul.dropdown-menu.dropdown-menu-right(role="menu")
                         li
                             a(href="https://github.com/MaxCDN/bootstrap-cdn",
-                                onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'GitHub project']);") GitHub project
+                                data-ga-category='Jumbotron actions',
+                                data-ga-action='Jumbotron links',
+                                data-ga-label='GitHub project') GitHub project
                         li
                             a(href="https://wordpress.org/plugins/bootstrapcdn/",
-                                onclick="_gaq.push(['_trackEvent', 'Jumbotron actions', 'Jumbotron links', 'WordPress Plugin']);") WordPress Plugin
+                                data-ga-category='Jumbotron actions',
+                                data-ga-action='Jumbotron links',
+                                data-ga-label='WordPress Plugin') WordPress Plugin
                         li
                             a(href="http://getbootstrap.com/",
-                                onclick="_gaq.push(['_trackEvent', 'Navigation', 'Resources', 'Bootstrap']);") Bootstrap
+                                data-ga-category='Navigation',
+                                data-ga-action='Resources',
+                                data-ga-label='Bootstrap') Bootstrap
                         li
                             a(href="http://expo.getbootstrap.com/",
-                                onclick="_gaq.push(['_trackEvent', 'Navigation', 'Resources', 'Expo']);") Bootstrap Expo
+                                data-ga-category='Navigation',
+                                data-ga-action='Resources',
+                                data-ga-label='Expo') Bootstrap Expo
                         li
                             a(href="http://fontawesome.io/",
-                                onclick="_gaq.push(['_trackEvent', 'Navigation', 'Resources', 'Font Awesome']);") Font Awesome
+                                data-ga-category='Navigation',
+                                data-ga-action='Resources',
+                                data-ga-label='Font Awesome') Font Awesome
                         li
                             a(href="http://bootswatch.com/",
-                                onclick="_gaq.push(['_trackEvent', 'Navigation', 'Resources', 'Bootswatch']);") Bootswatch
+                                data-ga-category='Navigation',
+                                data-ga-action='Resources',
+                                data-ga-label='Bootswatch') Bootswatch
                         li
                             a(href="https://github.com/twbs/bootlint"
-                                onclick="_gaq.push(['_trackEvent', 'Navigation', 'Resources', 'Bootlint']);") Bootlint
+                                data-ga-category='Navigation',
+                                data-ga-action='Resources',
+                                data-ga-label='Bootlint') Bootlint
                         li
                             a(href="https://glyphicons.com/",
-                                onclick="_gaq.push(['_trackEvent', 'Navigation', 'Resources', 'Glyphicons']);") Glyphicons
+                                data-ga-category='Navigation',
+                                data-ga-action='Resources',
+                                data-ga-label='Glyphicons') Glyphicons
 
 //- vim: ft=pug sw=4 sts=4 et:


### PR DESCRIPTION
This is something 1) I haven't used before myself and 2) most important, I can't check it myself since I don't have access to the GA account.

That being said, this is the last inline JavaScript we use and after that we can remove `unsafe-inline` from CSP `script-src`. So, we should definitely try and get this sorted.