### PR TITLE
Inline style.css and main.js.

### DIFF
--- a/config/_config.yml
+++ b/config/_config.yml
@@ -6,15 +6,10 @@ authors:
 description: BootstrapCDN
 favicon:
   uri: /assets/img/favicons/favicon.ico
-stylesheets:
-  style:
-    uri: /assets/css/style.css
 javascripts:
   jquery:
     uri: 'https://code.jquery.com/jquery-3.1.1.slim.min.js'
     sri: sha384-A7FZj7v+d/sdmMqp/nOQwliLvUsJfDHW+k9Omg/a/EheAdgtzNs3hpfag6Ed950n
-  main:
-    uri: /assets/js/main.js
 bootswatch:
   version: 3.3.7
   link: 'https://bootswatch.com/SWATCH_NAME/'

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "express-sslify": "^1.1.0",
     "helmet": "^3.1.0",
     "js-yaml": "^3.6.1",
+    "jstransformer-clean-css": "^1.1.2",
+    "jstransformer-uglify-js": "^1.1.1",
     "morgan": "^1.7.0",
     "pug": "^2.0.0-beta6",
     "serve-favicon": "^2.3.2",

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -29,10 +29,12 @@ html(lang='en')
         - fontawesome = config.fontawesome.filter(function(o) { return o.latest; })[0];
         link(rel='stylesheet', href=fontawesome.stylesheet, integrity=fontawesome.stylesheetSri, crossorigin='anonymous')
 
-        link(rel='stylesheet',
-            href=helpers.buster(config.stylesheets.style.uri),
-            integrity=generateSRI(config.stylesheets.style.uri),
-            crossorigin='anonymous')
+        if process.env.NODE_ENV == 'production'
+            style
+                include:clean-css /assets/css/style.css
+        else
+            style
+                include /assets/css/style.css
 
         block head
 
@@ -58,8 +60,11 @@ html(lang='en')
         script(src=bootstrap.javascript, integrity=bootstrap.javascriptSri,
             crossorigin='anonymous')
 
-        script(async src=helpers.buster(config.javascripts.main.uri),
-            integrity=generateSRI(config.javascripts.main.uri),
-            crossorigin='anonymous')
+        if process.env.NODE_ENV == 'production'
+            script(nonce=nonce)
+                include:uglify-js /assets/js/main.js
+        else
+            script(nonce=nonce)
+                include /assets/js/main.js
 
 //- vim: ft=pug sw=4 sts=4 et:


### PR DESCRIPTION
The reason for this is that these files are very small.

Older browsers will use `'unsafe-inline'`, newer ones will use the supplied `nonce`.