### PR TITLE
Add `body` class based on the page's title.

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -21,6 +21,16 @@ function appendLocals(req, res) {
         return pageTitle + ' &middot; ' + TITLE;
     };
 
+    res.locals.bodyClass = function (pageTitle) {
+        // Remove whitespace from title
+        var str = pageTitle.replace(' ', '');
+
+        // Make the first letter lowercase
+        str = str.charAt(0).toLowerCase() + str.slice(1);
+
+        return 'page-' + str;
+    };
+
     res.locals.generateSRI = function (file) {
         if (typeof SRI_CACHE[file] === 'undefined') {
             SRI_CACHE[file] = digest(path.join(__dirname, '..', 'public', file));

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -38,7 +38,7 @@ html(lang='en')
 
         block head
 
-    body
+    body(class=bodyClass(title))
         include _partials/header
 
         include _partials/jumbotron


### PR DESCRIPTION
This is mostly so that we can target page specific selectors more easily. My current patch isn't foolproof (escaping if needed etc), but should do the job for the time being.

If anyone has any improvement suggestions, please let me know.