### PR TITLE
Re-enable `content-length` check.

### DIFF
--- a/tests/functional_test.js
+++ b/tests/functional_test.js
@@ -26,9 +26,7 @@ var expectedHeaders = {
     'vary': 'Accept-Encoding',
 
     'content-type': undefined,
-
-    // Disabling temporarily until we figure out why this disappeared.
-    // 'content-length': undefined,
+    'content-length': undefined,
 
     'last-modified': undefined,
     'x-cache': undefined,


### PR DESCRIPTION
The issue seems to be fixed for some time now.