### PR TITLE
Update CSP directive.

### DIFF
--- a/app.js
+++ b/app.js
@@ -136,9 +136,9 @@ app.use(helmet.contentSecurityPolicy({
         ],
         fontSrc: [
             '\'self\'',
+            'maxcdn.bootstrapcdn.com',
             'fonts.gstatic.com'
         ],
-        manifestSrc: ['\'self\''],
         frameSrc: [
             '\'self\'',
             'platform.twitter.com',
@@ -151,6 +151,7 @@ app.use(helmet.contentSecurityPolicy({
             'syndication.twitter.com',
             'ghbtns.com'
         ],
+        manifestSrc: ['\'self\''],
         reportUri: [
             'https://d063bdf998559129f041de1efd2b41a5.report-uri.io/r/default/csp/enforce'
         ]


### PR DESCRIPTION
For some reason, Safari 10 complains about not being able to load the font files from the CDN, even though it shouldn't even try to download them in first place.

This should fix those errors.