### PR TITLE
Remove unneeded dependency serve-static.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "morgan": "^1.7.0",
     "pug": "^2.0.0-beta6",
     "serve-favicon": "^2.3.2",
-    "serve-static": "^1.11.1",
     "shelljs": "^0.5.3",
     "snyk": "^1.19.1",
     "sri-toolbox": "^0.2.0"


### PR DESCRIPTION
Express.js has this built-in.

Not sure if we need to require this explicitly.