### PR TITLE
refactoring config and specs

### DIFF
--- a/config/_config.yml
+++ b/config/_config.yml
@@ -11,7 +11,7 @@ javascripts:
   jquery:
     uri: 'https://code.jquery.com/jquery-3.2.1.slim.min.js'
     sri: sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN
-bootswatch:
+bootswatch3:
   version: 3.3.7
   link: 'https://bootswatch.com/3/SWATCH_NAME/'
   image: 'https://bootswatch.com/3/SWATCH_NAME/thumbnail.png'
@@ -146,7 +146,7 @@ bootlint:
   - version: 0.2.0
     javascript: 'https://maxcdn.bootstrapcdn.com/bootlint/0.2.0/bootlint.min.js'
     javascriptSri: sha384-OuU4cNKby6UDoPD/pWtrEhfGUWHZXIFGs/E8+mUnoDIdR98n/cL0RZcixIA0XlnS
-bootstrap:
+bootstrap3:
   - version: 3.3.7
     latest: true
     stylesheet: 'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css'

--- a/tests/bootstrap_legacy_test.js
+++ b/tests/bootstrap_legacy_test.js
@@ -15,7 +15,7 @@ before((done) => {
     });
 });
 
-describe('legacy', () => {
+describe('legacy/bootstrap', () => {
     it('works', (done) => {
         helpers.assert.response(response);
         done();
@@ -33,7 +33,7 @@ describe('legacy', () => {
         done();
     });
 
-    config.bootstrap.forEach((bootstrap) => {
+    config.bootstrap3.forEach((bootstrap) => {
         if (bootstrap.latest === true) {
             return;
         }

--- a/tests/bootswatch3_test.js
+++ b/tests/bootswatch3_test.js
@@ -10,7 +10,7 @@ let response = {};
 
 function format(str, name) {
     return str.replace('SWATCH_NAME', name)
-                .replace('SWATCH_VERSION', config.bootswatch.version);
+                .replace('SWATCH_VERSION', config.bootswatch3.version);
 }
 
 before((done) => {
@@ -20,14 +20,14 @@ before((done) => {
     });
 });
 
-describe('bootswatch', () => {
+describe('bootswatch3', () => {
     it('works', (done) => {
         helpers.assert.response(response);
         done();
     });
 
     it('has header', (done) => {
-        helpers.assert.contains('<h2 class="text-center mb-4">Bootswatch</h2>', response.body);
+        helpers.assert.contains('<h2 class="text-center mb-4">Bootswatch 3</h2>', response.body);
         done();
     });
 
@@ -38,13 +38,12 @@ describe('bootswatch', () => {
         done();
     });
 
-    config.bootswatch.themes.forEach((theme) => {
-        const name  = theme.name;
-        const image = format(config.bootswatch.image, theme.name);
-        const uri   = format(config.bootswatch.bootstrap, theme.name);
+    config.bootswatch3.themes.forEach((theme) => {
+        const image = format(config.bootswatch3.image, theme.name);
+        const uri   = format(config.bootswatch3.bootstrap, theme.name);
         const sri   = theme.sri;
 
-        describe(name, () => {
+        describe(theme.name, () => {
             describe('config', () => {
                 it('has integrity', (done) => {
                     assert(typeof sri !== 'undefined');

--- a/tests/bootswatch4_test.js
+++ b/tests/bootswatch4_test.js
@@ -39,12 +39,11 @@ describe('bootswatch4', () => {
     });
 
     config.bootswatch4.themes.forEach((theme) => {
-        const name  = theme.name;
         const image = format(config.bootswatch4.image, theme.name);
         const uri   = format(config.bootswatch4.bootstrap, theme.name);
         const sri   = theme.sri;
 
-        describe(name, () => {
+        describe(theme.name, () => {
             describe('config', () => {
                 it('has integrity', (done) => {
                     assert(typeof sri !== 'undefined');

--- a/tests/functional_test.js
+++ b/tests/functional_test.js
@@ -89,8 +89,8 @@ function assertHeader(uri, header) {
 }
 
 describe('functional', () => {
-    describe('bootstrap', () => {
-        config.bootstrap.forEach((self) => {
+    describe('bootstrap3', () => {
+        config.bootstrap3.forEach((self) => {
             describe(helpers.domainCheck(self.javascript), () => {
                 const uri = helpers.domainCheck(self.javascript);
 
@@ -117,10 +117,10 @@ describe('functional', () => {
         });
     });
 
-    describe('bootswatch', () => {
-        config.bootswatch.themes.forEach((theme) => {
-            const uri = helpers.domainCheck(config.bootswatch.bootstrap
-                .replace('SWATCH_VERSION', config.bootswatch.version)
+    describe('bootswatch3', () => {
+        config.bootswatch3.themes.forEach((theme) => {
+            const uri = helpers.domainCheck(config.bootswatch3.bootstrap
+                .replace('SWATCH_VERSION', config.bootswatch3.version)
                 .replace('SWATCH_NAME', theme.name));
 
             describe(uri, () => {

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -15,7 +15,7 @@ before((done) => {
     });
 });
 
-describe('bootstrap4', () => {
+describe('bootstrap4 block', () => {
     const latest = config.bootstrap4[0];
 
     describe('config', () => {
@@ -51,11 +51,6 @@ describe('bootstrap4', () => {
         });
         done();
     });
-
-    //it('has header', (done) => {
-    //    helpers.assert.contains('<h2 class="text-center mb-4">Bootstrap 4 Beta</h2>', response.body);
-    //    done();
-    //});
 
     it('has notice', (done) => {
         helpers.assert.contains('Bootstrap 4 is currently in Beta release and should be treated as such.', response.body);
@@ -100,8 +95,8 @@ describe('bootstrap4', () => {
     });
 });
 
-describe('index', () => {
-    const latest = config.bootstrap[0];
+describe('bootstrap3 block', () => {
+    const latest = config.bootstrap3[0];
 
     describe('config', () => {
         it('is latest', (done) => {

--- a/views/index.pug
+++ b/views/index.pug
@@ -8,9 +8,10 @@ block content
     h3.text-center.mt-4=`v${config.bootstrap4[0].version}`
 
     .card.bg-light.mt-4.p-4.text-center
-        -var name   = 'quickstartCSS'.toLowerCase() + config.bootstrap4[0].version.replace(/\./g, '_');
-        -var file   = config.bootstrap4[0].stylesheet;
-        -var sri    = config.bootstrap4[0].stylesheetSri;
+        -var latest = config.bootstrap4[0];
+        -var name   = 'quickstartCSS'.toLowerCase() + latest.version.replace(/\./g, '_');
+        -var file   = latest.stylesheet;
+        -var sri    = latest.stylesheetSri;
         -var formId = name + '_form';
 
         .form-group.my-4
@@ -24,9 +25,9 @@ block content
 
         include _partials/csscode.pug
 
-        -var name   = 'quickstartJS'.toLowerCase() + config.bootstrap4[0].version.replace(/\./g, '_');
-        -var file   = config.bootstrap4[0].javascript;
-        -var sri    = config.bootstrap4[0].javascriptSri;
+        -var name   = 'quickstartJS'.toLowerCase() + latest.version.replace(/\./g, '_');
+        -var file   = latest.javascript;
+        -var sri    = latest.javascriptSri;
         -var formId = name + '_form';
 
         .form-group.my-4
@@ -40,9 +41,9 @@ block content
 
         include _partials/jscode.pug
 
-        -var name   = 'quickstartJSBundle'.toLowerCase() + config.bootstrap4[0].version.replace(/\./g, '_');
-        -var file   = config.bootstrap4[0].javascriptBundle;
-        -var sri    = config.bootstrap4[0].javascriptBundleSri;
+        -var name   = 'quickstartJSBundle'.toLowerCase() + latest.version.replace(/\./g, '_');
+        -var file   = latest.javascriptBundle;
+        -var sri    = latest.javascriptBundleSri;
         -var formId = name + '_form';
 
         .form-group.my-4
@@ -58,12 +59,13 @@ block content
 
     hr.my-4
 
-    h3.text-center=`v${config.bootstrap[0].version}`
+    -var latest = config.bootstrap3[0];
+    h3.text-center=`v${latest.version}`
 
     .card.bg-light.mt-4.p-4.text-center
-        -var name   = 'quickstartCSS'.toLowerCase() + config.bootstrap[0].version.replace(/\./g, '_');
-        -var file   = config.bootstrap[0].stylesheet;
-        -var sri    = config.bootstrap[0].stylesheetSri;
+        -var name   = 'quickstartCSS'.toLowerCase() + latest.version.replace(/\./g, '_');
+        -var file   = latest.stylesheet;
+        -var sri    = latest.stylesheetSri;
         -var formId = name + '_form';
 
         .form-group.my-4
@@ -77,9 +79,9 @@ block content
 
         include _partials/csscode.pug
 
-        -var name   = 'quickstartJS'.toLowerCase() + config.bootstrap[0].version.replace(/\./g, '_');
-        -var file   = config.bootstrap[0].javascript;
-        -var sri    = config.bootstrap[0].javascriptSri;
+        -var name   = 'quickstartJS'.toLowerCase() + latest.version.replace(/\./g, '_');
+        -var file   = latest.javascript;
+        -var sri    = latest.javascriptSri;
         -var formId = name + '_form';
 
         .form-group.my-4

--- a/views/legacy/bootstrap.pug
+++ b/views/legacy/bootstrap.pug
@@ -57,7 +57,7 @@ block content
 
                     include ../_partials/jscode.pug
 
-    each item in config.bootstrap
+    each item in config.bootstrap3
         unless (item.latest)
             .card.bg-light.text-center.mt-4.px-4
                 h2.mt-2=item.version

--- a/views/legacy/bootswatch.pug
+++ b/views/legacy/bootswatch.pug
@@ -1,19 +1,19 @@
 extends ../layout.pug
 
 block content
-    h2.text-center.mb-4 Bootswatch
+    h2.text-center.mb-4 Bootswatch 3
 
-    -for (var i = 0, len = config.bootswatch.themes.length; i < len; i++)
-        -var name = config.bootswatch.themes[i].name.toLowerCase();
-        -var sri  = config.bootswatch.themes[i].sri;
-        -var file = config.bootswatch.bootstrap.replace('SWATCH_NAME', name).replace('SWATCH_VERSION', config.bootswatch.version);
+    -for (var i = 0, len = config.bootswatch3.themes.length; i < len; i++)
+        -var name = config.bootswatch3.themes[i].name.toLowerCase();
+        -var sri  = config.bootswatch3.themes[i].sri;
+        -var file = config.bootswatch3.bootstrap.replace('SWATCH_NAME', name).replace('SWATCH_VERSION', config.bootswatch3.version);
 
         .card.bg-light.my-4.p-4.text-center
             .row
                 .col-sm-12.col-md-8.offset-md-2
                     .mt-4
-                        a(href=config.bootswatch.link.replace('SWATCH_NAME', name), target='_blank', rel='noopener')
-                            img.bootswatch.d-block.img-fluid.mx-auto(src=config.bootswatch.image.replace('SWATCH_NAME', name), alt=name + ' thumbnail', width='528', height='317')
+                        a(href=config.bootswatch3.link.replace('SWATCH_NAME', name), target='_blank', rel='noopener')
+                            img.bootswatch.d-block.img-fluid.mx-auto(src=config.bootswatch3.image.replace('SWATCH_NAME', name), alt=name + ' thumbnail', width='528', height='317')
                         .input-group.mt-3
                             input.form-control(type='text', value=file)
                             span.input-group-btn


### PR DESCRIPTION
Creating this as a PR to #890 because I want to discuss before merging.

I ran out of time today before my meetings start, but in addition to these changes, I'd like to:

1. Rename "Legacy" to "Archives".
1. Remove the "Old Versions" dropdown, instead having "Bootswatch 3" and "Bootstrap Archives" nav buttons. My thinking is, "legacy/bootstrap" and "legacy/bootswatch" are actually different things. "legacy/bootstrap" is really more of an archive of older versions, which "legacy/bootswatch" is really "Bootswatch 3" (as I've renamed it in this PR).
