### PR TITLE
Load Twitter timeline manually.

### DIFF
--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -71,6 +71,25 @@
 
     })();
 
+    function initTwitterTimeline() {
+        if (!window.matchMedia('(min-width: 992px)').matches) {
+            return;
+        }
+
+        window.twttr.ready(function(twttr) {
+            twttr.widgets.createTimeline(
+                {
+                    sourceType: 'collection',
+                    id: '770731482377621505'
+                },
+                document.querySelector('.twitter-timeline-custom'),
+                {
+                    height: 525,
+                    partner: 'tweetdeck'
+                }
+            );
+        });
+    }
 
     (function loadScripts() {
         function loadGhbtns() {
@@ -108,9 +127,11 @@
         function onLoad() {
             loadGhbtns();
             loadTwitterScript();
+            initTwitterTimeline();
         }
 
         window.addEventListener('load', onLoad, false);
+        window.addEventListener('resize', initTwitterTimeline, false);
     })();
 
 

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -75,7 +75,7 @@ html(lang='en', prefix='og: http://ogp.me/ns#', itemscope, itemtype='http://sche
                         .col-sm-12
                             include _partials/carbonads.pug
                         .col-sm-12.d-none.d-lg-block
-                            a.twitter-timeline(href='https://twitter.com/getBootstrapCDN/timelines/770731482377621505', data-height='525', data-partner='tweetdeck') Mad Love - Curated tweets by getBootstrapCDN
+                            .twitter-timeline-custom
 
         script(src=config.javascripts.jquery.uri,
             integrity=config.javascripts.jquery.sri, crossorigin='anonymous')


### PR DESCRIPTION
This allows us to skip loading it when we are on < 992px, where we don't show the timeline anyway.

Should make mobile browsing much faster, we need to test this good before merging.

`window.matchMedia` is available for our supported browsers so we should be all good there.