### PR TITLE
Removing assert.contains helper for better failure messaging

### DIFF
--- a/tests/bootlint_test.js
+++ b/tests/bootlint_test.js
@@ -32,7 +32,8 @@ describe('bootlint', () => {
     });
 
     it('works', (done) => {
-        helpers.assert.response(response);
+        assert(response);
+        assert.equal(200, response.statusCode);
         done();
     });
 
@@ -42,18 +43,21 @@ describe('bootlint', () => {
 
     it('contains authors', (done) => {
         config.authors.forEach((author) => {
-            helpers.assert.contains(author, response.body);
+            assert(response.body.includes(author),
+                `Expects response body to include "${author}"`);
         });
         done();
     });
 
     it('has header', (done) => {
-        helpers.assert.contains('<h2 class="text-center mb-4">Bootlint</h2>', response.body);
+        assert(response.body.includes('<h2 class="text-center mb-4">Bootlint</h2>'),
+            'Expects response body to include Bootlint header');
         done();
     });
 
     it('has javascript', (done) => {
-        helpers.assert.contains(latest.javascript, response.body);
+        assert(response.body.includes(latest.javascript),
+            `Expects response body to include "${latest.javascript}"`);
         done();
     });
 
@@ -61,7 +65,7 @@ describe('bootlint', () => {
         it(`has ${fmt}`, (done) => {
             const str = helpers.javascript[fmt](latest.javascript, latest.javascriptSri);
 
-            helpers.assert.contains(str, response.body);
+            assert(response.body.includes(str), `Expects response body to include "${str}"`);
             done();
         });
     });

--- a/tests/bootstrap_legacy_test.js
+++ b/tests/bootstrap_legacy_test.js
@@ -17,7 +17,8 @@ before((done) => {
 
 describe('legacy/bootstrap', () => {
     it('works', (done) => {
-        helpers.assert.response(response);
+        assert(response);
+        assert.equal(200, response.statusCode);
         done();
     });
 
@@ -26,13 +27,14 @@ describe('legacy/bootstrap', () => {
     });
 
     it('has header', (done) => {
-        helpers.assert.contains('<h2 class="text-center mb-4">Bootstrap Legacy</h2>', response.body);
+        assert(response.body.includes('<h2 class="text-center mb-4">Bootstrap Legacy</h2>'),
+            'Expected response body to include Bootstrap Legacy header');
         done();
     });
 
     it('contains authors', (done) => {
         config.authors.forEach((author) => {
-            helpers.assert.contains(author, response.body);
+            assert(response.body.includes(author), `Expected response body to include "${author}"`);
         });
         done();
     });
@@ -58,14 +60,14 @@ describe('legacy/bootstrap', () => {
                 it(`has javascript ${fmt}`, (done) => {
                     const str = helpers.javascript[fmt](bootstrap.javascript, bootstrap.javascriptSri);
 
-                    helpers.assert.contains(str, response.body);
+                    assert(response.body.includes(str), `Expected response body to include "${str}"`);
                     done();
                 });
 
                 it(`has stylesheet ${fmt}`, (done) => {
                     const str = helpers.css[fmt](bootstrap.stylesheet, bootstrap.stylesheetSri);
 
-                    helpers.assert.contains(str, response.body);
+                    assert(response.body.includes(str), `Expected response body to include "${str}"`);
                     done();
                 });
             });

--- a/tests/bootswatch3_test.js
+++ b/tests/bootswatch3_test.js
@@ -22,7 +22,8 @@ before((done) => {
 
 describe('bootswatch3', () => {
     it('works', (done) => {
-        helpers.assert.response(response);
+        assert(response);
+        assert.equal(200, response.statusCode);
         done();
     });
 
@@ -31,13 +32,14 @@ describe('bootswatch3', () => {
     });
 
     it('has header', (done) => {
-        helpers.assert.contains('<h2 class="text-center mb-4">Bootswatch 3</h2>', response.body);
+        assert(response.body.includes('<h2 class="text-center mb-4">Bootswatch 3</h2>'),
+            'Expects response body to include Bootswatch 3 header');
         done();
     });
 
     it('contains authors', (done) => {
         config.authors.forEach((author) => {
-            helpers.assert.contains(author, response.body);
+            assert(response.body.includes(author), `Expects response body to include "${author}"`);
         });
         done();
     });
@@ -56,7 +58,7 @@ describe('bootswatch3', () => {
             });
 
             it('has image', (done) => {
-                helpers.assert.contains(image, response.body);
+                assert(response.body.includes(image), `Expects response body to include "${image}"`);
                 done();
             });
 
@@ -64,7 +66,7 @@ describe('bootswatch3', () => {
                 it(`has ${fmt}`, (done) => {
                     const str = helpers.css[fmt](uri, sri);
 
-                    helpers.assert.contains(str, response.body);
+                    assert(response.body.includes(str), `Expects response body to include "${str}"`);
                     done();
                 });
             });

--- a/tests/bootswatch4_test.js
+++ b/tests/bootswatch4_test.js
@@ -22,7 +22,8 @@ before((done) => {
 
 describe('bootswatch4', () => {
     it('works', (done) => {
-        helpers.assert.response(response);
+        assert(response);
+        assert.equal(200, response.statusCode);
         done();
     });
 
@@ -31,13 +32,14 @@ describe('bootswatch4', () => {
     });
 
     it('has header', (done) => {
-        helpers.assert.contains('<h2 class="text-center mb-4">Bootswatch 4 Beta</h2>', response.body);
+        assert(response.body.includes('<h2 class="text-center mb-4">Bootswatch 4 Beta</h2>'),
+            'Expects response body to include Bootswatch 4 Beta header');
         done();
     });
 
     it('contains authors', (done) => {
         config.authors.forEach((author) => {
-            helpers.assert.contains(author, response.body);
+            assert(response.body.includes(author), `Expects response body to include "${author}"`);
         });
         done();
     });
@@ -56,7 +58,8 @@ describe('bootswatch4', () => {
             });
 
             it('has image', (done) => {
-                helpers.assert.contains(image, response.body);
+                assert(response.body.includes(image),
+                    `Expects response body to include "${image}"`);
                 done();
             });
 
@@ -64,7 +67,7 @@ describe('bootswatch4', () => {
                 it(`has ${fmt}`, (done) => {
                     const str = helpers.css[fmt](uri, sri);
 
-                    helpers.assert.contains(str, response.body);
+                    assert(response.body.includes(str), `Expects response body to include "${str}"`);
                     done();
                 });
             });

--- a/tests/fontawesome_test.js
+++ b/tests/fontawesome_test.js
@@ -31,7 +31,8 @@ describe('fontawesome', () => {
     });
 
     it('works', (done) => {
-        helpers.assert.response(response);
+        assert(response);
+        assert.equal(200, response.statusCode);
         done();
     });
 
@@ -41,18 +42,20 @@ describe('fontawesome', () => {
 
     it('contains authors', (done) => {
         config.authors.forEach((author) => {
-            helpers.assert.contains(author, response.body);
+            assert(response.body.includes(author), `Expected response body to inculde "${author}"`);
         });
         done();
     });
 
     it('has header', (done) => {
-        helpers.assert.contains('<h2 class="text-center mb-4">Font Awesome</h2>', response.body);
+        assert(response.body.includes('<h2 class="text-center mb-4">Font Awesome</h2>'),
+            'Expected response body to include Font Awesome header');
         done();
     });
 
     it('has stylesheet', (done) => {
-        helpers.assert.contains(latest.stylesheet, response.body);
+        assert(response.body.includes(latest.stylesheet),
+            `Expected response body to include "${latest.stylesheet}"`);
         done();
     });
 
@@ -60,7 +63,7 @@ describe('fontawesome', () => {
         it(`has ${fmt}`, (done) => {
             const str = helpers.css[fmt](latest.stylesheet, latest.stylesheetSri);
 
-            helpers.assert.contains(str, response.body);
+            assert(response.body.includes(str), `Expected response body to include "${str}"`);
             done();
         });
     });

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -41,25 +41,28 @@ describe('bootstrap4 block', () => {
     });
 
     it('works', (done) => {
-        helpers.assert.response(response);
+        assert(response);
+        assert.equal(200, response.statusCode);
         done();
     });
 
     it('contains authors', (done) => {
         config.authors.forEach((author) => {
-            helpers.assert.contains(author, response.body);
+            assert(response.body.includes(author), `Expects response body to include "${author}"`);
         });
         done();
     });
 
     it('has notice', (done) => {
-        helpers.assert.contains('Bootstrap 4 is currently in Beta release and should be treated as such.', response.body);
+        assert(response.body.includes('Bootstrap 4 is currently in Beta release and should be treated as such.'),
+            'Expects response body to include beta messaging');
         done();
     });
 
     describe('stylesheet', () => {
         it('has uri', (done) => {
-            helpers.assert.contains(latest.stylesheet, response.body);
+            assert(response.body.includes(latest.stylesheet),
+                `Expects response body to include "${latest.stylesheet}"`);
             done();
         });
 
@@ -67,7 +70,7 @@ describe('bootstrap4 block', () => {
             it(`has ${fmt}`, (done) => {
                 const str = helpers.css[fmt](latest.stylesheet, latest.stylesheetSri);
 
-                helpers.assert.contains(str, response.body);
+                assert(response.body.includes(str), `Expects response body to include "${str}"`);
                 done();
             });
         });
@@ -75,12 +78,14 @@ describe('bootstrap4 block', () => {
 
     describe('javascript', () => {
         it('has javascript uri', (done) => {
-            helpers.assert.contains(latest.javascript, response.body);
+            assert(response.body.includes(latest.javascript),
+                `Expects response body to include "${latest.javascript}"`);
             done();
         });
 
         it('has javascript bundle uri', (done) => {
-            helpers.assert.contains(latest.javascriptBundle, response.body);
+            assert(response.body.includes(latest.javascriptBundle),
+                `Expects response body to include "${latest.javascriptBundle}"`);
             done();
         });
 
@@ -88,7 +93,7 @@ describe('bootstrap4 block', () => {
             it(`has ${fmt}`, (done) => {
                 const str = helpers.javascript[fmt](latest.javascript, latest.javascriptSri);
 
-                helpers.assert.contains(str, response.body);
+                assert(response.body.includes(str), `Expects response body to include "${str}"`);
                 done();
             });
         });
@@ -116,7 +121,8 @@ describe('bootstrap3 block', () => {
     });
 
     it('works', (done) => {
-        helpers.assert.response(response);
+        assert(response);
+        assert.equal(200, response.statusCode);
         done();
     });
 
@@ -126,19 +132,22 @@ describe('bootstrap3 block', () => {
 
     it('contains authors', (done) => {
         config.authors.forEach((author) => {
-            helpers.assert.contains(author, response.body);
+            assert(response.body.includes(author),
+                `Expects response body to include "${author}"`);
         });
         done();
     });
 
     it('has header', (done) => {
-        helpers.assert.contains('<h2 class="text-center">Quick Start</h2>', response.body);
+        assert(response.body.includes('<h2 class="text-center">Quick Start</h2>'),
+            'Expects response body to include Quick Start header');
         done();
     });
 
     describe('stylesheet', () => {
         it('has uri', (done) => {
-            helpers.assert.contains(latest.stylesheet, response.body);
+            assert(response.body.includes(latest.stylesheet),
+                `Expects response body to include "${latest.stylesheet}"`);
             done();
         });
 
@@ -146,7 +155,7 @@ describe('bootstrap3 block', () => {
             it(`has ${fmt}`, (done) => {
                 const str = helpers.css[fmt](latest.stylesheet, latest.stylesheetSri);
 
-                helpers.assert.contains(str, response.body);
+                assert(response.body.includes(str), `Expects response body to include "${str}"`);
                 done();
             });
         });
@@ -154,7 +163,8 @@ describe('bootstrap3 block', () => {
 
     describe('javascript', () => {
         it('has javascript uri', (done) => {
-            helpers.assert.contains(latest.javascript, response.body);
+            assert(response.body.includes(latest.javascript),
+                `Expects response body to include "${latest.javascript}"`);
             done();
         });
 
@@ -162,7 +172,7 @@ describe('bootstrap3 block', () => {
             it(`has ${fmt}`, (done) => {
                 const str = helpers.javascript[fmt](latest.javascript, latest.javascriptSri);
 
-                helpers.assert.contains(str, response.body);
+                assert(response.body.includes(str), `Expects response body to include "${str}"`);
                 done();
             });
         });

--- a/tests/integrations_test.js
+++ b/tests/integrations_test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path     = require('path');
+const assert   = require('assert');
 const helpers  = require(path.join(__dirname, 'test_helper.js'));
 const config   = helpers.config();
 const uri      = helpers.app(config, 'integrations');
@@ -16,7 +17,8 @@ before((done) => {
 
 describe('integrations', () => {
     it('works', (done) => {
-        helpers.assert.response(response);
+        assert(response);
+        assert.equal(200, response.statusCode);
         done();
     });
 
@@ -26,32 +28,38 @@ describe('integrations', () => {
 
     it('contains authors', (done) => {
         config.authors.forEach((author) => {
-            helpers.assert.contains(author, response.body);
+            assert(response.body.includes(author),
+                `Expects response body to include "${author}"`);
         });
         done();
     });
 
     it('has header', (done) => {
-        helpers.assert.contains('<h2 class="text-center mb-4">Integrations</h2>', response.body);
+        assert(response.body.includes('<h2 class="text-center mb-4">Integrations</h2>'),
+            'Expects response body to include Integration header');
         done();
     });
 
     config.integrations.forEach((integration) => {
         describe(integration.name, () => {
             it('has name', (done) => {
-                helpers.assert.contains(integration.name, response.body);
+                assert(response.body.includes(integration.name),
+                    `Expects response body to include "${integration.name}"`);
                 done();
             });
             it('has image', (done) => {
-                helpers.assert.contains(integration.img, response.body);
+                assert(response.body.includes(integration.img),
+                    `Expects response body to include "${integration.img}"`);
                 done();
             });
             it('has platform', (done) => {
-                helpers.assert.contains(integration.plat, response.body);
+                assert(response.body.includes(integration.plat),
+                    `Expects response body to include "${integration.plat}"`);
                 done();
             });
             it('has url', (done) => {
-                helpers.assert.contains(integration.url, response.body);
+                assert(response.body.includes(integration.url),
+                    `Expects response body to include "${integration.url}"`);
                 done();
             });
         });

--- a/tests/showcase_test.js
+++ b/tests/showcase_test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path     = require('path');
+const assert   = require('assert');
 const helpers  = require(path.join(__dirname, 'test_helper.js'));
 const config   = helpers.config();
 const uri      = helpers.app(config, 'showcase');
@@ -16,7 +17,8 @@ before((done) => {
 
 describe('showcase', () => {
     it('works', (done) => {
-        helpers.assert.response(response);
+        assert(response);
+        assert.equal(200, response.statusCode);
         done();
     });
 
@@ -26,32 +28,37 @@ describe('showcase', () => {
 
     it('contains authors', (done) => {
         config.authors.forEach((author) => {
-            helpers.assert.contains(author, response.body);
+            assert(response.body.includes(author), `Expects response bodt to include "${author}"`);
         });
         done();
     });
 
     it('has header', (done) => {
-        helpers.assert.contains('<h2 class="text-center mb-4">Showcase</h2>', response.body);
+        assert(response.body.includes('<h2 class="text-center mb-4">Showcase</h2>'),
+            'Expects response body to include Showcase header');
         done();
     });
 
     config.showcase.forEach((showcase) => {
         describe(showcase.name, () => {
             it('has name', (done) => {
-                helpers.assert.contains(showcase.name, response.body);
+                assert(response.body.includes(showcase.name),
+                    `Expects response body to include "${showcase.name}"`);
                 done();
             });
             it('has image', (done) => {
-                helpers.assert.contains(showcase.img, response.body);
+                assert(response.body.includes(showcase.img),
+                    `Expects response body to include "${showcase.img}"`);
                 done();
             });
             it('has lib', (done) => {
-                helpers.assert.contains(showcase.lib, response.body);
+                assert(response.body.includes(showcase.lib),
+                    `Expects response body to include "${showcase.lib}"`);
                 done();
             });
             it('has url', (done) => {
-                helpers.assert.contains(showcase.url, response.body);
+                assert(response.body.includes(showcase.url),
+                    `Expects response body to include "${showcase.url}"`);
                 done();
             });
         });

--- a/tests/test_helper.js
+++ b/tests/test_helper.js
@@ -80,15 +80,6 @@ function app(config, endpoint) {
     return format('http://localhost:%s%s', process.env.PORT, endpoint);
 }
 
-function assertResponse(response, code = 200) {
-    assert(response);
-    assert.equal(code, response.statusCode);
-}
-
-function assertContains(needle, haystack) {
-    assert(haystack.includes(needle));
-}
-
 function assertValidHTML(response, done) {
     const options = {
         data: response.body,
@@ -178,8 +169,6 @@ module.exports = {
     config,
     app,
     assert: {
-        response:    assertResponse,
-        contains:    assertContains,
         contentType: assertContentType,
         validHTML:   assertValidHTML
     },


### PR DESCRIPTION
1. Removed `helper.assert.contains` in favor of `assert(response.body.includes(...), "messaging")`. Currently find debugging test failure a bit annoying due to lack of proper messaging.
2. Removed `helper.assert.response` in favor of in-test asserts. With the helper, the failure messaging was obfuscated. 

I chose to leave the other assert helpers for now as they provide a bit more "help".