### PR TITLE
Add back height for `.social`.

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -12,6 +12,10 @@
     line-height: 1.2;
 }
 
+.social {
+    height: 25px;
+}
+
 iframe {
     border: 0;
     overflow: hidden;


### PR DESCRIPTION
This prevent page jumping while the badges are being loaded.

Regression of 0f0b0712b25a0709da140fed1e49aa65eb66b3d5.