### PR TITLE
Improve cache busting

### DIFF
--- a/app.js
+++ b/app.js
@@ -83,12 +83,6 @@ app.use(compression());
 
 app.use(favicon(path.join(PUBLIC_DIR, config.favicon.uri), '7d'));
 
-app.use(serveStatic(PUBLIC_DIR, {
-    maxAge: '30d',
-    lastModified: true,
-    etag: false
-}));
-
 app.use((req, res, next) => {
     // make config available in routes
     req.config = config;
@@ -102,8 +96,17 @@ app.use((req, res, next) => {
 
     res.locals.nonce = Buffer.from(uuid.v4(), 'utf-8').toString('base64');
 
+    // Rewrite the versioned assets
+    req.url = req.url.replace(/\/([^/]+)\.[0-9a-f]+\.(\w+)$/, '/$1.$2');
+
     next();
 });
+
+app.use(serveStatic(path.join(__dirname, 'public'), {
+    maxAge: '30d',
+    lastModified: true,
+    etag: false
+}));
 
 app.use(helmet({
     dnsPrefetchControl: false,

--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@ const enforce      = require('express-sslify');
 const sitemap      = require('express-sitemap');
 const helmet       = require('helmet');
 const Rollbar      = require('rollbar');
+const staticify    = require('staticify');
 
 const helpers      = require('./lib/helpers.js');
 const routes       = require('./routes');
@@ -80,6 +81,7 @@ if (env === 'production') {
 
 // middleware
 app.use(compression());
+app.use(staticify(PUBLIC_DIR).middleware);
 
 app.use(favicon(path.join(PUBLIC_DIR, config.favicon.uri), '7d'));
 
@@ -96,13 +98,10 @@ app.use((req, res, next) => {
 
     res.locals.nonce = Buffer.from(uuid.v4(), 'utf-8').toString('base64');
 
-    // Rewrite the versioned assets
-    req.url = req.url.replace(/\/([^/]+)\.[0-9a-f]+\.(\w+)$/, '/$1.$2');
-
     next();
 });
 
-app.use(serveStatic(path.join(__dirname, 'public'), {
+app.use(serveStatic(PUBLIC_DIR, {
     maxAge: '30d',
     lastModified: true,
     etag: false
@@ -218,6 +217,7 @@ app.use(helmet.contentSecurityPolicy({
 app.locals.helpers = helpers;
 app.locals.config = config;
 app.locals.basedir = PUBLIC_DIR;
+app.locals.getVersionedPath = staticify(PUBLIC_DIR).getVersionedPath;
 
 // routes
 app.get('/fontawesome/', routes.fontawesome);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,43 +1,7 @@
 'use strict';
 
 const fs  = require('fs');
-const crypto = require('crypto');
-const path = require('path');
-const url = require('url');
 const sri = require('sri-toolbox');
-
-function buster(uri) {
-    // Parse the uri
-    const urlObj = url.parse(uri);
-
-    const urlProtocol = urlObj.protocol;
-    const urlPathname = urlObj.pathname;
-    const urlHostname = urlObj.hostname;
-
-    // The position of the last instance of forward slash,
-    // including the slash itself
-    const fileNamePos = urlPathname.lastIndexOf('/') + 1;
-    // The position of the last instance of period,
-    // without the period itself
-    const fileExtPos = urlPathname.lastIndexOf('.');
-
-    // The url part from the beginning until the last forward slash
-    const pathnameWithoutFile = urlPathname.substring(0, fileNamePos);
-    const filename = urlPathname.substring(fileNamePos, fileExtPos);
-    const ext = urlPathname.substring(fileExtPos);
-
-    const fileStr = fs.readFileSync(path.join(__dirname, '../public/', urlPathname));
-    const hash = crypto.createHash('md5')
-                    .update(fileStr)
-                    .digest('hex')
-                    .slice(0, 7);
-
-    let bustedAsset = `${urlProtocol ? urlProtocol : ''}${urlHostname ? `//${urlHostname}` : ''}`;
-
-    bustedAsset += `${pathnameWithoutFile + filename}.${hash}${ext}`;
-
-    return bustedAsset;
-}
 
 function sriDigest(file, fromString) {
     file = fromString ? file : fs.readFileSync(file);
@@ -73,8 +37,7 @@ module.exports = {
     },
     sri: {
         digest: sriDigest
-    },
-    buster
+    }
 };
 
 // vim: ft=javascript sw=4 sts=4 et:

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,13 +1,42 @@
 'use strict';
 
 const fs  = require('fs');
+const crypto = require('crypto');
+const path = require('path');
+const url = require('url');
 const sri = require('sri-toolbox');
 
-// create datestamp on startup
-const cacheBuster = Date.now().toString();
-
 function buster(uri) {
-    return `${uri}?${cacheBuster}`;
+    // Parse the uri
+    const urlObj = url.parse(uri);
+
+    const urlProtocol = urlObj.protocol;
+    const urlPathname = urlObj.pathname;
+    const urlHostname = urlObj.hostname;
+
+    // The position of the last instance of forward slash,
+    // including the slash itself
+    const fileNamePos = urlPathname.lastIndexOf('/') + 1;
+    // The position of the last instance of period,
+    // without the period itself
+    const fileExtPos = urlPathname.lastIndexOf('.');
+
+    // The url part from the beginning until the last forward slash
+    const pathnameWithoutFile = urlPathname.substring(0, fileNamePos);
+    const filename = urlPathname.substring(fileNamePos, fileExtPos);
+    const ext = urlPathname.substring(fileExtPos);
+
+    const fileStr = fs.readFileSync(path.join(__dirname, '../public/', urlPathname));
+    const hash = crypto.createHash('md5')
+                    .update(fileStr)
+                    .digest('hex')
+                    .slice(0, 7);
+
+    let bustedAsset = `${urlProtocol ? urlProtocol : ''}${urlHostname ? `//${urlHostname}` : ''}`;
+
+    bustedAsset += `${pathnameWithoutFile + filename}.${hash}${ext}`;
+
+    return bustedAsset;
 }
 
 function sriDigest(file, fromString) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4744,6 +4744,14 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
       "integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ="
     },
+    "staticify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/staticify/-/staticify-1.0.0.tgz",
+      "integrity": "sha512-rNH8/QFnWIqFMZSEv63STl0zPdmMQ1pufM7BhD8JcjLuOYWjqCu3UXCzge5nPW2IcPZdh1pLcswTBcJYrGH+vg==",
+      "requires": {
+        "send": "0.16.1"
+      }
+    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "serve-favicon": "^2.4.5",
     "serve-static": "^1.13.1",
     "sri-toolbox": "^0.2.0",
+    "staticify": "^1.0.0",
     "uglify-js": "^2.8.29",
     "uuid": "^3.1.0"
   },

--- a/tests/integrations_test.js
+++ b/tests/integrations_test.js
@@ -1,10 +1,14 @@
 'use strict';
 
-const assert   = require('assert');
-const helpers  = require('./test_helper.js');
+const assert     = require('assert');
+const path       = require('path');
+const staticify  = require('staticify');
+const helpers    = require('./test_helper.js');
 
-const config   = helpers.config();
-const uri      = helpers.app(config, 'integrations');
+const config     = helpers.config();
+const uri        = helpers.app(config, 'integrations');
+
+const PUBLIC_DIR = path.join(__dirname, '../public');
 
 let response = {};
 
@@ -48,7 +52,7 @@ describe('integrations', () => {
                 done();
             });
             it('has image', (done) => {
-                assert(response.body.includes(integration.img),
+                assert(response.body.includes(staticify(PUBLIC_DIR).getVersionedPath(integration.img)),
                     `Expects response body to include "${integration.img}"`);
                 done();
             });

--- a/tests/showcase_test.js
+++ b/tests/showcase_test.js
@@ -1,10 +1,14 @@
 'use strict';
 
-const assert   = require('assert');
-const helpers  = require('./test_helper.js');
+const assert     = require('assert');
+const path       = require('path');
+const staticify  = require('staticify');
+const helpers    = require('./test_helper.js');
 
-const config   = helpers.config();
-const uri      = helpers.app(config, 'showcase');
+const config     = helpers.config();
+const uri        = helpers.app(config, 'showcase');
+
+const PUBLIC_DIR = path.join(__dirname, '../public');
 
 let response = {};
 
@@ -47,7 +51,7 @@ describe('showcase', () => {
                 done();
             });
             it('has image', (done) => {
-                assert(response.body.includes(showcase.img),
+                assert(response.body.includes(staticify(PUBLIC_DIR).getVersionedPath(showcase.img)),
                     `Expects response body to include "${showcase.img}"`);
                 done();
             });

--- a/views/_partials/integrations.pug
+++ b/views/_partials/integrations.pug
@@ -1,7 +1,7 @@
 .card.py-4.mb-3.text-center
     .card-body
         a(href=item.url, target='_blank', rel='noopener')
-            img.card-img-top.img-fluid.d-block(src=helpers.buster(item.img), alt=item.name + ' Screenshot', width='443', height='289')
+            img.card-img-top.img-fluid.d-block(src=getVersionedPath(item.img), alt=item.name + ' Screenshot', width='443', height='289')
         h3.card-title.my-2
             a(href=item.url, target='_blank', rel='noopener')=item.name
         p.m-0.

--- a/views/_partials/showcase.pug
+++ b/views/_partials/showcase.pug
@@ -1,7 +1,7 @@
 .card.py-2.mb-3.text-center
     .card-body
         a(href=item.url, target='_blank', rel='noopener')
-            img.card-img-top.img-fluid.d-block(src=helpers.buster(item.img), alt=item.name + ' Screenshot', width='443', height='289')
+            img.card-img-top.img-fluid.d-block(src=getVersionedPath(item.img), alt=item.name + ' Screenshot', width='443', height='289')
         h3.card-title.my-2
             a(href=item.url, target='_blank', rel='noopener')=item.name
         p.m-0.

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -18,12 +18,12 @@ html(lang='en', prefix='og: http://ogp.me/ns#', itemscope, itemtype='http://sche
         link(rel='dns-prefetch', href='//code.jquery.com')
         link(rel='dns-prefetch', href='//fonts.googleapis.com')
 
-        link(rel='apple-touch-icon', href=helpers.buster('/assets/img/favicons/apple-touch-icon.png'), sizes='180x180')
-        link(rel='icon', type='image/png', href=helpers.buster('/assets/img/favicons/favicon-32x32.png'), sizes='32x32')
-        link(rel='icon', type='image/png', href=helpers.buster('/assets/img/favicons/favicon-16x16.png'), sizes='16x16')
+        link(rel='apple-touch-icon', href=getVersionedPath('/assets/img/favicons/apple-touch-icon.png'), sizes='180x180')
+        link(rel='icon', type='image/png', href=getVersionedPath('/assets/img/favicons/favicon-32x32.png'), sizes='32x32')
+        link(rel='icon', type='image/png', href=getVersionedPath('/assets/img/favicons/favicon-16x16.png'), sizes='16x16')
         link(rel='manifest', href='/assets/img/favicons/manifest.json')
         link(rel='mask-icon', href='/assets/img/favicons/safari-pinned-tab.svg', color='#00afec')
-        link(rel='shortcut icon', href=helpers.buster('/assets/img/favicons/favicon.ico'))
+        link(rel='shortcut icon', href=getVersionedPath('/assets/img/favicons/favicon.ico'))
         meta(name='msapplication-config', content='/assets/img/favicons/browserconfig.xml')
         meta(name='theme-color', content='#222222')
 
@@ -31,8 +31,8 @@ html(lang='en', prefix='og: http://ogp.me/ns#', itemscope, itemtype='http://sche
         meta(property='og:type', content='website')
         meta(property='og:description', content!=pageDescription)
         meta(property='og:url', content=siteUrl)
-        meta(property='og:image', content=helpers.buster(siteUrl.replace(/^https:/, 'http:') + '/assets/img/og.png'))
-        meta(property='og:image:secure_url', content=helpers.buster(siteUrl + '/assets/img/og.png'))
+        meta(property='og:image', content=getVersionedPath(siteUrl.replace(/^https:/, 'http:') + '/assets/img/og.png'))
+        meta(property='og:image:secure_url', content=getVersionedPath(siteUrl + '/assets/img/og.png'))
         meta(property='og:image:type', content='image/png')
         meta(property='og:image:width', content='256')
         meta(property='og:image:height', content='256')
@@ -44,7 +44,7 @@ html(lang='en', prefix='og: http://ogp.me/ns#', itemscope, itemtype='http://sche
 
         meta(itemprop='name', content!=title)
         meta(itemprop='description', content!=pageDescription)
-        meta(itemprop='image', content=helpers.buster('/assets/img/og.png'))
+        meta(itemprop='image', content=getVersionedPath('/assets/img/og.png'))
 
         -var bootswatch = helpers.theme.fetch(config, theme);
         link(rel='stylesheet', href=bootswatch.uri, integrity=bootswatch.sri,


### PR DESCRIPTION
@jmervine: here's the pros and cons

1. My solution works fine too, but it's like reinventing the wheel when there's a package that does the same. Also the staticify package provides a middleware so we don't need to redirect the hashed assets ourselves. **With my solution the hashed assets are served with a cache of 0 so we'll need to tweak this if we go with it.**
2. staticify's middleware has its own settings, so what we set for serve-static, doesn't apply here. Not a huge deal since we can provide upstream patches and improve it, but currently the hashed assets are served with **a cache of 1 year (which is OK) but with an etag set**.
3. staticify causes a slowdown when the server process starts, because it scans the whole directory. We could provide an upstream patch to improve this.
4. The advantage of all this is that our hashed assets now, will still be in the browser's cache even when our server process is restarted, since their hash is independent of the date the server process was started.

[Here](https://github.com/errorception/staticify/issues) are the issues I have currently opened, any help to improve this for our needs (and everyone else's) appreciated :)

Let me know with which solution we should go. I prefer the staticify solution and provide upstream patches.