### PR TITLE
Remove Glyphicons from the Resources dropdown.

### DIFF
--- a/views/_partials/header.pug
+++ b/views/_partials/header.pug
@@ -41,13 +41,6 @@ nav.navbar.navbar-expand-lg.navbar-dark.bg-dark
                             target='_blank',
                             rel='noopener') GitHub project
                     li.dropdown-item.bg-dark
-                        a.nav-link(href='https://wordpress.org/plugins/bootstrapcdn/',
-                            data-ga-category='Navigation',
-                            data-ga-action='Resources',
-                            data-ga-label='WordPress Plugin',
-                            target='_blank',
-                            rel='noopener') WordPress Plugin
-                    li.dropdown-item.bg-dark
                         a.nav-link(href='https://getbootstrap.com/',
                             data-ga-category='Navigation',
                             data-ga-action='Resources',

--- a/views/_partials/header.pug
+++ b/views/_partials/header.pug
@@ -82,12 +82,5 @@ nav.navbar.navbar-expand-lg.navbar-dark.bg-dark
                             data-ga-label='Bootlint',
                             target='_blank',
                             rel='noopener') Bootlint
-                    li.dropdown-item.bg-dark
-                        a.nav-link(href='https://glyphicons.com/',
-                            data-ga-category='Navigation',
-                            data-ga-action='Resources',
-                            data-ga-label='Glyphicons',
-                            target='_blank',
-                            rel='noopener') Glyphicons
 
 //- vim: ft=pug sw=4 sts=4 et:


### PR DESCRIPTION
Bootstrap 4 doesn't use it.